### PR TITLE
Upgrade pulumi-terraform-bridge to v3.80.0

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -8,7 +8,7 @@ replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraf
 
 require (
 	github.com/lukasaron/terraform-provider-stripe v1.9.6
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.79.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.80.0
 	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2801,8 +2801,8 @@ github.com/pulumi/providertest v0.0.11 h1:mg8MQ7Cq7+9XlHIkBD+aCqQO4mwAJEISngZgVd
 github.com/pulumi/providertest v0.0.11/go.mod h1:HsxjVsytcMIuNj19w1lT2W0QXY0oReXl1+h6eD2JXP8=
 github.com/pulumi/pulumi-java/pkg v0.10.0 h1:D1i5MiiNrxYr2uJ1szcj1aQwF9DYv7TTsPmajB9dKSw=
 github.com/pulumi/pulumi-java/pkg v0.10.0/go.mod h1:xu6UgYtQm+xXOo1/DZNa2CWVPytu+RMkZVTtI7w7ffY=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.79.0 h1:h0HlgUsqaQAe57/+AP9kbhHo5SLI0uwl8lstjVG+I9U=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.79.0/go.mod h1:U5CqG4BJmdzCd4ALO2cx/dEP0yTHfIS2sk2ah1ngZq4=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.80.0 h1:A+LvNkIIPYokCyGJG6eO+rlZge1my/Bj7ouZbiwC7AM=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.80.0/go.mod h1:VzIl/lDqPfHpYq2UQQvY6YHeSXwt0+riqc8eNpK+ElA=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 h1:mav2tSitA9BPJPLLahKgepHyYsMzwaTm4cvp0dcTMYw=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8/go.mod h1:qUYk2c9i/yqMGNj9/bQyXpS39BxNDSXYjVN1njnq0zY=
 github.com/pulumi/pulumi-yaml v1.6.0 h1:mb/QkebWXTa1fR+P3ZkCCHGXOYC6iTN8X8By9eNz8xM=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider georgegebbett/pulumi-stripe --kind=all --target-bridge-version=latest`.

---

- Upgrading pulumi-terraform-bridge from v3.79.0 to v3.80.0.
